### PR TITLE
feat: employee log in system

### DIFF
--- a/app/admin/employees.rb
+++ b/app/admin/employees.rb
@@ -57,11 +57,9 @@ ActiveAdmin.register Employee do
       f.input :last_name
       f.input :nickname
       f.input :active
-      f.input :email
-      if f.employee.new_record?
-        f.input :password
-        f.input :password_confirmation
-      end
+      f.input :email, { required: false }
+      f.input :password, { required: false }
+      f.input :password_confirmation
       f.input :employee_type, as: :select, collection: [ [ "Regular", "regular" ], [ "Contractual", "contractual" ], [ "Probationary", "probationary" ] ], include_blank: false
       f.input :status, as: :select, collection: [ [ "Active", "active" ], [ "Inactive", "inactive" ] ], include_blank: false
 

--- a/app/admin/employees.rb
+++ b/app/admin/employees.rb
@@ -3,7 +3,9 @@ ActiveAdmin.register Employee do
                 :last_name,
                 :nickname,
                 :active,
-                :status
+                :status,
+                :employee_type,
+                :email
 
   actions :all, except: [ :destroy ]
 
@@ -16,6 +18,8 @@ ActiveAdmin.register Employee do
     column :first_name
     column :last_name
     column :nickname
+    column :email
+    column :employee_type
     column :active
     column :status do |employee| employee.status.capitalize end
     column :created_at
@@ -30,6 +34,11 @@ ActiveAdmin.register Employee do
       row :last_name
       row :nickname
       row :active
+      row :email
+
+      row :employee_type do |employee|
+        employee.employee_type.capitalize
+      end
 
       row :status do |employee|
         employee.status.capitalize
@@ -46,6 +55,8 @@ ActiveAdmin.register Employee do
       f.input :last_name
       f.input :nickname
       f.input :active
+      f.input :email
+      f.input :employee_type, as: :select, collection: [ [ "Regular", "regular" ], [ "Contractual", "contractual" ], [ "Probationary", "probationary" ] ], include_blank: false
       f.input :status, as: :select, collection: [ [ "Active", "active" ], [ "Inactive", "inactive" ] ], include_blank: false
 
       f.actions

--- a/app/admin/employees.rb
+++ b/app/admin/employees.rb
@@ -5,7 +5,9 @@ ActiveAdmin.register Employee do
                 :active,
                 :status,
                 :employee_type,
-                :email
+                :email,
+                :password,
+                :password_confirmation
 
   actions :all, except: [ :destroy ]
 
@@ -56,6 +58,10 @@ ActiveAdmin.register Employee do
       f.input :nickname
       f.input :active
       f.input :email
+      if f.employee.new_record?
+        f.input :password
+        f.input :password_confirmation
+      end
       f.input :employee_type, as: :select, collection: [ [ "Regular", "regular" ], [ "Contractual", "contractual" ], [ "Probationary", "probationary" ] ], include_blank: false
       f.input :status, as: :select, collection: [ [ "Active", "active" ], [ "Inactive", "inactive" ] ], include_blank: false
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
 
   # prompt change password after first time sign in
   def after_sign_in_path_for(resource)
-    if current_employee.sign_in_count == 1
+    if !current_employee.nil? && current_employee.sign_in_count == 1
       edit_employee_registration_path
     else
       root_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,13 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: { safari: 16.4, firefox: 121, ie: false }
+
+  # prompt change password after first time sign in
+  def after_sign_in_path_for(resource)
+    if current_employee.sign_in_count == 1
+      edit_employee_registration_path
+    else
+      root_path
+    end
+  end
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -2,5 +2,16 @@ class Employee < ApplicationRecord
   has_many :reimbursements
   has_many :reimbursement_items
 
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+
   validates :nickname, presence: true, uniqueness: true
+  validates :email, uniqueness: true, allow_nil: true
+
+  protected
+
+  def email_required?
+    # TODO: validate this later on with employee_type
+    false
+  end
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -8,7 +8,22 @@ class Employee < ApplicationRecord
   validates :nickname, presence: true, uniqueness: true
   validates :email, uniqueness: true, allow_nil: true
 
+  before_validation :convert_blank_to_nil
+
+  private
+
+  def convert_blank_to_nil
+    if email.blank?
+      self.email = nil
+    end
+  end
+
   protected
+
+  def password_required?
+    # TODO: validate this later on with employee_type
+    false
+  end
 
   def email_required?
     # TODO: validate this later on with employee_type

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -3,12 +3,18 @@ class Employee < ApplicationRecord
   has_many :reimbursement_items
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable
 
   validates :nickname, presence: true, uniqueness: true
   validates :email, uniqueness: true, allow_nil: true
 
   before_validation :convert_blank_to_nil
+
+  # override trackable method
+  def update_tracked_fields(request)
+    self.sign_in_count ||= 0
+    self.sign_in_count += 1
+  end
 
   private
 
@@ -20,6 +26,7 @@ class Employee < ApplicationRecord
 
   protected
 
+  # override validatable methods to allow blank emails
   def password_required?
     # TODO: validate this later on with employee_type
     false

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -4,7 +4,7 @@
       <a class="navbar-brand" href="/">
         <%= image_tag("loudcloud_logo.png", width: 90, height: 35) %>
       </a>
-    </div>
+  </div>
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav">
         <li class="nav-item">
@@ -15,7 +15,14 @@
       </ul>
     </div>
     <div class="">
-      <a class="btn btn-outline-primary" href="<%= admin_user_session_path %>">Sign In</a>
+      <% if employee_signed_in? %>
+        Hello, <%= current_employee.nickname %>
+        <a class="btn btn-outline-primary" href="<%= destroy_employee_session_path  %>" data-turbo-method="delete">Sign out</a>
+      <% else %>
+        <a class="btn btn-outline-primary" href="<%= new_employee_session_path %>">Sign in</a>
+      <% end %>
+      
+      <a class="btn btn-outline-primary" href="<%= admin_user_session_path %>">Sign in as admin</a>
     </div>
   </div>
 </nav>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).
@@ -252,7 +252,7 @@ Devise.setup do |config|
 
   # Set this configuration to false if you want /users/sign_out to sign out
   # only the current scope. By default, Devise signs out all scopes.
-  # config.sign_out_all_scopes = true
+  config.sign_out_all_scopes = false
 
   # ==> Navigation configuration
   # Lists the formats that should be treated as navigational. Formats like

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
+
+  devise_for :employees
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20241204064203_add_devise_to_employees.rb
+++ b/db/migrate/20241204064203_add_devise_to_employees.rb
@@ -1,0 +1,43 @@
+class AddDeviseToEmployees < ActiveRecord::Migration[8.0]
+  def change
+    change_table :employees do |t|
+      ## Database authenticatable
+      t.string :employee_type,      default: nil
+
+      t.string :email,              null: true, default: nil
+      t.string :encrypted_password, null: true, default: nil
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      # t.timestamps null: false
+    end
+
+    add_index :employees, :email,                unique: true
+    add_index :employees, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+  end
+end

--- a/db/migrate/20241204064203_add_devise_to_employees.rb
+++ b/db/migrate/20241204064203_add_devise_to_employees.rb
@@ -15,7 +15,7 @@ class AddDeviseToEmployees < ActiveRecord::Migration[8.0]
       t.datetime :remember_created_at
 
       ## Trackable
-      # t.integer  :sign_in_count, default: 0, null: false
+      t.integer  :sign_in_count, default: 0, null: false
       # t.datetime :current_sign_in_at
       # t.datetime :last_sign_in_at
       # t.string   :current_sign_in_ip

--- a/db/migrate/20241204064203_add_devise_to_employees.rb
+++ b/db/migrate/20241204064203_add_devise_to_employees.rb
@@ -36,7 +36,7 @@ class AddDeviseToEmployees < ActiveRecord::Migration[8.0]
       # t.timestamps null: false
     end
 
-    add_index :employees, :email,                unique: true
+    add_index :employees, :email,                unique: true, where: "email != '' AND email IS NOT NULL"
     add_index :employees, :reset_password_token, unique: true
     # add_index :users, :confirmation_token,   unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_03_030155) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_04_064203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -86,6 +86,15 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_03_030155) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "active", default: true, null: false
+    t.string "employee_type"
+    t.string "email"
+    t.string "encrypted_password"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.index ["email"], name: "index_employees_on_email", unique: true, where: "(((email)::text <> ''::text) AND (email IS NOT NULL))"
+    t.index ["reset_password_token"], name: "index_employees_on_reset_password_token", unique: true
   end
 
   create_table "reimbursement_items", force: :cascade do |t|


### PR DESCRIPTION
## Changelog

### Features

#### Model
- added new fields to `Employee` model
    - `employee_type` - regular, contractual, or probationary
    - `email` - `devise` field, nullable (for contractuals)
    - `password` - `devise` field, nullable (for contractuals)
    - `sign_in_count` - `devise` field, from trackable module (for password reset prompt)
        - other trackable fields not included for now as they're not needed 
- add `devise` modules to `Employee`
    - all default modules plus `trackable` 
- add overrides to certain `devise` functions
    - `update_tracked_fields` - modified to only change `sign_in_count` since other fields weren't added
    - `email_required` and `password_required` - made them false to allow null values (for contractuals)

#### View
- Active Admin
    - added new employee fields
    - accounts are registered when an admin creates a new employee
    - admin can set a temporary password
    - email and password are optional, to account for contractual employees
- Homepage
    - Log in functinoality for employees
        - added "Sign in" button for employees 
            - admin sign in is now "Sign in as admin" 
        - on first sign in, they redirected to password update form
        - on successful sign in, the navbar should show the logged in employee  ("Hello, [nickname]")
   

## How to check
- run `rails db:migrate`
- log in to an admin account
- create a new employee, or edit an existing employee to set their credentials
- go back to back at the main page, click on "Sign in"
- enter the credentials set by admin
- verify that password update form appears, and update password accordingly
- verify that the navbar shows the logged in user
- log out the user, then log in again
- verify that password update form doesn't appear anymore
