### PR TITLE
feat: login views and navbar updates

### DIFF
--- a/app/views/employees/confirmations/new.html.erb
+++ b/app/views/employees/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "employees/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "employees/shared/links" %>

--- a/app/views/employees/mailer/confirmation_instructions.html.erb
+++ b/app/views/employees/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/employees/mailer/email_changed.html.erb
+++ b/app/views/employees/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/employees/mailer/password_change.html.erb
+++ b/app/views/employees/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/employees/mailer/reset_password_instructions.html.erb
+++ b/app/views/employees/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/employees/mailer/unlock_instructions.html.erb
+++ b/app/views/employees/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/employees/passwords/edit.html.erb
+++ b/app/views/employees/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "employees/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "employees/shared/links" %>

--- a/app/views/employees/passwords/edit.html.erb
+++ b/app/views/employees/passwords/edit.html.erb
@@ -1,25 +1,31 @@
-<h2>Change your password</h2>
+<div class="container mt-5">
+  <div class="col-5 mx-auto p-4 shadow">
+    <div class="form-group row my-4 px-3">
+      <h2 class="fw-semibold text-center">Change your password</h2>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "employees/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "employees/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <div class="form-group my-3 px-3 field">
+        <%= f.label :password, "New password", class: "form-label" %>
+        <% if @minimum_password_length %>
+          <em class="form-text">(<%= @minimum_password_length %> characters minimum)</em>
+        <% end %>
+        <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "form-control" %>
+      </div>
+
+      <div class="form-group my-3 px-3 field">
+        <%= f.label :password_confirmation, "Confirm new password", class: "form-label" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+      </div>
+
+      <div class="actions my-4 px-3">
+        <%= f.submit "Change my password", class: "btn w-100 btn-primary" %>
+      </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= link_to "Back to sign in page", new_session_path(resource_name), class: "px-3" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "employees/shared/links" %>
+</div>

--- a/app/views/employees/passwords/new.html.erb
+++ b/app/views/employees/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "employees/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "employees/shared/links" %>

--- a/app/views/employees/passwords/new.html.erb
+++ b/app/views/employees/passwords/new.html.erb
@@ -1,16 +1,22 @@
-<h2>Forgot your password?</h2>
+<div class="container mt-5">
+  <div class="col-5 mx-auto p-4 shadow">
+    <div class="form-group row my-4 px-3">
+      <h2 class="fw-semibold text-center">Forgot your password?</h2>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "employees/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "employees/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="form-group my-3 px-3 field">
+        <%= f.label :email, class: "form-label" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+      </div>
+
+      <div class="actions my-4 px-3">
+        <%= f.submit "Send me reset password instructions", class: "btn w-100 btn-primary" %>
+      </div>
+    <% end %>
+
+    <%= link_to "Back to sign in page", new_session_path(resource_name), class: "px-3" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "employees/shared/links" %>
+</div>

--- a/app/views/employees/registrations/edit.html.erb
+++ b/app/views/employees/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "employees/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+
+<%= link_to "Back", :back %>

--- a/app/views/employees/registrations/edit.html.erb
+++ b/app/views/employees/registrations/edit.html.erb
@@ -1,43 +1,51 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="container mt-5">
+  <div class="col-5 mx-auto p-4 shadow">
+    <div class="form-group row my-4 px-3">
+      <h2 class="fw-semibold text-center">Edit <%= resource_name.to_s.humanize %></h2>
+    </div>
+      <% if current_employee.sign_in_count == 1 %>
+        <div class="form-group my-3 px-3">
+          <div class="alert alert-info" role="alert">
+            Please change your temporary password.
+          </div>
+        </div>
+      <% end %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "employees/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "employees/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div class="form-group my-3 px-3 field">
+        <%= f.label :email, class: "form-label" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+      </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+      <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <div class="form-group my-3 px-3 field">
+        <%= f.label :password, class: "form-label" %> <i class="form-text">(leave blank if you don't want to change it)</i>
+        <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+        <% if @minimum_password_length %>
+          <em class="form-text"><%= @minimum_password_length %> characters minimum</em>
+        <% end %>
+      </div>
+
+      <div class="form-group my-3 px-3 field">
+        <%= f.label :password_confirmation, class: "form-label" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+      </div>
+
+      <div class="form-group my-3 px-3 field">
+        <%= f.label :current_password, class: "form-label" %> <i class="form-text">(type your current password to confirm changes)</i>
+        <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
+      </div>
+
+      <div class="actions my-4 px-3">
+        <%= f.submit "Update", class: "btn w-100 btn-primary" %>
+      </div>
     <% end %>
+
+    <%= link_to "Back", :back, class: "px-3" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/employees/registrations/edit.html.erb
+++ b/app/views/employees/registrations/edit.html.erb
@@ -1,22 +1,23 @@
 <div class="container mt-5">
   <div class="col-5 mx-auto p-4 shadow">
     <div class="form-group row my-4 px-3">
-      <h2 class="fw-semibold text-center">Edit <%= resource_name.to_s.humanize %></h2>
+      <h2 class="fw-semibold text-center">Update <%= resource_name.to_s.humanize %></h2>
     </div>
-      <% if current_employee.sign_in_count == 1 %>
-        <div class="form-group my-3 px-3">
-          <div class="alert alert-info" role="alert">
-            Please change your temporary password.
-          </div>
+
+    <% if current_employee.sign_in_count == 1 %>
+      <div class="form-group my-3 px-3">
+        <div class="alert alert-info" role="alert">
+          Please change your temporary password.
         </div>
-      <% end %>
+      </div>
+    <% end %>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <%= render "employees/shared/error_messages", resource: resource %>
 
       <div class="form-group my-3 px-3 field">
         <%= f.label :email, class: "form-label" %>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", disabled: true  %>
       </div>
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>

--- a/app/views/employees/registrations/new.html.erb
+++ b/app/views/employees/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "employees/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "employees/shared/links" %>

--- a/app/views/employees/sessions/new.html.erb
+++ b/app/views/employees/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "current-password" %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "employees/shared/links" %>

--- a/app/views/employees/sessions/new.html.erb
+++ b/app/views/employees/sessions/new.html.erb
@@ -1,26 +1,37 @@
-<h2>Log in</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+<div class="container mt-5">
+  <div class="col-5 mx-auto p-4 shadow">
+    <div class="form-group row my-4 px-3">
+      <h2 class="fw-semibold text-center">Employee Sign in</h2>
     </div>
-  <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="form-group my-3 px-3 field">
+        <%= f.label :email, class: "form-label" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+      </div>
+
+      <div class="form-group my-3 px-3 field">
+        <%= f.label :password, class: "form-label" %>
+        <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
+      </div>
+
+      <div class="form-group row my-2 px-3 field">
+        <% if devise_mapping.rememberable? %>
+          <div class="col-6">
+            <%= f.check_box :remember_me, class: "form-check-input" %>
+            <%= f.label :remember_me, class: "form-check-label" %>
+          </div>
+        <% end %>
+        <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+          <div class="col-6 text-end px-3">
+            <%= link_to "Forgot password?", new_password_path(resource_name) %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="actions my-4 px-3">
+        <%= f.submit "Log in", class: "btn w-100 btn-primary" %>
+      </div>
+    <% end %>
   </div>
-<% end %>
-
-<%= render "employees/shared/links" %>
+</div>

--- a/app/views/employees/shared/_error_messages.html.erb
+++ b/app/views/employees/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" data-turbo-cache="false">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/employees/shared/_links.html.erb
+++ b/app/views/employees/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+  <% end %>
+<% end %>

--- a/app/views/employees/unlocks/new.html.erb
+++ b/app/views/employees/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "employees/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "employees/shared/links" %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg">
+<nav class="navbar navbar-expand-lg shadow-sm">
   <div class="container-fluid">
     <div>
       <a class="navbar-brand" href="/">
@@ -7,22 +7,52 @@
   </div>
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" aria-current="page" href="<%= new_reimbursement_path(employee_id: params[:employee_id]) %>">
-            File Reimbursement
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            Budget Tracker
           </a>
+          <div class="dropdown-menu">
+            <a class="dropdown-item" href="/">Dashboard</a>
+            <a class="dropdown-item" href="<%= new_reimbursement_path(employee_id: params[:employee_id]) %>">
+              File Reimbursement
+            </a>
+          </div>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle <%= 'disabled' if !employee_signed_in? %>" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            Leaves Tracker
+          </a>
+          <div class="dropdown-menu">
+            <a class="dropdown-item disabled" href="/">Dashboard</a>
+            <a class="dropdown-item disabled" href="<%= new_reimbursement_path(employee_id: params[:employee_id]) %>">
+              File Leave
+            </a>
+          </div>
         </li>
       </ul>
     </div>
-    <div class="">
+    <div class="d-flex align-items-center">
       <% if employee_signed_in? %>
-        Hello, <%= current_employee.nickname %>
-        <a class="btn btn-outline-primary" href="<%= destroy_employee_session_path  %>" data-turbo-method="delete">Sign out</a>
+        <div class="dropdown mx-3">
+          <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <span style="width: 36px; height: 36px;" class="mx-2 border border-secondary border-2 rounded-circle d-flex align-items-center justify-content-center">
+              <i class="fa-regular fa-user"></i>
+            </span>
+            <%= current_employee.nickname %> 
+          </a>
+          <div class="dropdown-menu">
+            <a class="dropdown-item" href="<%= edit_employee_registration_path %>">Update password</a>
+            <a class="dropdown-item" href="<%= destroy_employee_session_path  %>" data-turbo-method="delete">Sign out</a>
+          </div>
+        </div>
       <% else %>
-        <a class="btn btn-outline-primary" href="<%= new_employee_session_path %>">Sign in</a>
+        <a class="btn btn-primary mx-2" href="<%= new_employee_session_path %>">Sign in</a>
       <% end %>
-      
-      <a class="btn btn-outline-primary" href="<%= admin_user_session_path %>">Sign in as admin</a>
+      <% if admin_user_signed_in? %>
+        <a class="btn btn-outline-primary" href="<%= admin_root_path %>">Go to admin module</a>
+      <% else %>
+        <a class="btn btn-outline-primary mx-2" href="<%= admin_user_session_path %>">Sign in as admin</a>
+      <% end %>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
## Changelog

### Features

#### View
- generated `devise` views for customization
    - added bootstrap classes to the views currently accessible by employees:
        - login page (`sessions/new`)
        - password reset request (`passwords/new`)
        - password reset form (`passwords/edit`)
        - edit employee credentials (`registrations/edit`)
            - on first login, user is redirected here with a notice to change their temporary password
            - email field disabled
- updated navbar
    - navigation between modules
        - navigation dropdown items "Budget Tracker" and "Leaves Tracker"
            - Budget Tracker: has "Dashboard" and "File Reimbursement" under it, routed to their corresponding views
            - Leaves Tracker: will contain leave features for later, items don't do anything for now
                - module is disabled entirely if employee isn't signed in
    - updated display for logged in user
        - user nickname is displayed as a dropdown
            - added a user icon (temporarily just so it looks nice)
            - dropdown has links that route to update password and sign out
    - nit: added a check for `admin_user_signed_in?` for admin sign in
        - such that that it only links back to Active Admin rather than attempting login again when already logged in


## How to check
- start app and verify new navbar layout
    - verify that leaves module is disabled when not logged in
- log in to an employee account
- verify that leaves module becomes enabled (though does nothing for now)
- verify dropdown display for logged in user
    - verify that the links work as they should ("Update password" leads to `registrations/edit`, "Sign out" will sign out the user)
