### PR TITLE
feat: leaves index page (part 2) and filing for someone else

### DIFF
--- a/app/admin/leaves.rb
+++ b/app/admin/leaves.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register Leave do
                 :reason,
                 :status
 
-  actions :all, except: [ :new, :create, :destroy ]
+  actions :all, except: [ :destroy ]
 
   action_item :approve, only: :show, if: proc { resource.status == "pending" } do
     link_to "Approve", approve_admin_leave_path(resource), method: :put, class: "button"

--- a/app/helpers/leaves_helper.rb
+++ b/app/helpers/leaves_helper.rb
@@ -10,4 +10,12 @@ module LeavesHelper
       "text-bg-secondary"
     end
   end
+
+  def get_type_border(type)
+    if type == "sick"
+      "border-warning"
+    elsif type == "vacation"
+      "border-info"
+    end
+  end
 end

--- a/app/javascript/controllers/leave_request_controller.js
+++ b/app/javascript/controllers/leave_request_controller.js
@@ -2,9 +2,20 @@ import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="leave-request"
 export default class extends Controller {
-  static targets = ["startDate", "endDate", "dayCount"];
+  static targets = [
+    "startDate",
+    "endDate",
+    "dayCount",
+    "remainingSL",
+    "remainingVL",
+  ];
 
-  connect() {}
+  connect() {
+    this.selectedType = document.querySelector(
+      "input[type='radio']:checked",
+    )?.value;
+    this.errors = [];
+  }
 
   handleStartDateChange() {
     const startDate = this.startDateTarget.value;
@@ -55,6 +66,40 @@ export default class extends Controller {
     )
       .toISOString()
       .slice(0, 10);
+  }
+
+  handleTypeSelect(event) {
+    this.selectedType = event.target.value;
+  }
+
+  validateForm(event) {
+    const selectedType = this.selectedType;
+    const dayCount = this.dayCountTarget.value;
+    let remainingLeaves = 15;
+
+    if (selectedType == "sick") {
+      remainingLeaves = parseInt(this.remainingSLTarget.innerHTML);
+    } else if (selectedType == "vacation") {
+      remainingLeaves = parseInt(this.remainingVLTarget.innerHTML);
+    }
+
+    if (dayCount > remainingLeaves) {
+      event.preventDefault();
+      this.errors.push(
+        "Day count cannot be greater than your remaining leaves.",
+      );
+    }
+
+    this.showErrors();
+  }
+
+  showErrors() {
+    if (this.errors.length > 0) {
+      let errorText = "";
+      this.errors.forEach((error) => (errorText += error + "<br />"));
+      document.getElementById("frontendErrors").innerHTML = errorText;
+      document.getElementById("frontendErrors").removeAttribute("hidden");
+    }
   }
 
   getWeekdayCount(startDate, endDate) {

--- a/app/models/leave.rb
+++ b/app/models/leave.rb
@@ -12,17 +12,24 @@ class Leave < ApplicationRecord
 
   validate :end_date_must_be_after_start_date, :day_count_must_be_in_range
 
+  scope :sick_leaves, -> { where(leave_type: "sick") }
+  scope :vacation_leaves, -> { where(leave_type: "vacation") }
+  scope :pending_leaves, -> { where(status: "pending").order("start_date asc") }
+  scope :approved_leaves, -> { where(status: "approved").order("start_date asc") }
+  scope :counted_leaves, -> { where(status: [ "pending", "approved" ]) }
+  scope :uncounted_leaves, -> { where(status: [ "rejected", "cancelled" ]) }
+
   private
 
   def end_date_must_be_after_start_date
     if start_date.present? && end_date.present? && start_date > end_date
-      errors.add(:end_date, "must be after the start date")
+      errors.add(:end_date, "must be after the start date.")
     end
   end
 
   def day_count_must_be_in_range
     if day_count > 15 || day_count < 1
-      errors.add(:day_count, "must be between 1 to 15 days")
+      errors.add(:day_count, "must be between 1 to 15 days.")
     end
   end
 end

--- a/app/views/leaves/_form.html.erb
+++ b/app/views/leaves/_form.html.erb
@@ -1,55 +1,74 @@
-<%= form_with(model: @leave, data: { controller: "leave-request" }) do |f| %>
+<%= render 'shared/flashes' %>
+<%= render 'shared/toast' %>
+<% if @leave.errors.any? %>
+  <% @leave.errors.full_messages.each do |message| %>
+    <div class="alert alert-danger"><%= message %></div>
+  <% end %>
+<% end %>
+<div id="frontendErrors" class="alert alert-danger" hidden></div>
+
+<%= form_with(model: @leave, data: { controller: "leave-request", action: "submit->leave-request#validateForm" }) do |f| %>
   <div class="row my-2">
-      <%= f.label :approver_id, class: "form-label" %>
-      <%= f.collection_select :approver_id, @approvers || [], :id, :email, { prompt: "Select an approver" }, class: "form-select", required: true%>
+    <%= f.label :approver_id, class: "form-label" %>
+    <span>
+      <%= f.collection_select :approver_id, @approvers || [], :id, :email, { prompt: "Select an approver" }, class: "form-select", required: true %>
+    </span>
   </div>
   <div class="row my-2">
-      <div class="col-5">
+    <div class="col-5">
       <%= f.label :start_date, class: "form-label" %>
       <%= f.date_field :start_date, class: "form-control", required: true,
-          data: {
+        data: {
           "leave-request-target": "startDate",
           action: "change->leave-request#handleStartDateChange"
-          } %>
+        } %>
       </div>
       <div class="col-5">
       <%= f.label :end_date, class: "form-label" %>
       <%= f.date_field :end_date, class: "form-control", required: true,
-          data: {
+        data: {
           "leave-request-target": "endDate",
           action: "change->leave-request#handleEndDateChange"
-          } %>
+        } %>
       </div>
       <div class="col-2">
       <%= f.label :day_count, class: "form-label" %>
       <%= f.number_field :day_count, class: "form-control", min: 1, max: 15, required: true, 
-          data: {
+        data: {
           "leave-request-target": "dayCount",
           action: "input->leave-request#handleDayCountChange"
-          } %>
-      </div>
+        } %>
+    </div>
   </div>
   <div class="row my-2">
-      <div class="col-5">
-      <%= f.label :leave_type, class: "form-label", required: true %>
+    <div class="col-5">
+      <%= f.label :leave_type, class: "form-label" %>
       <div class="border rounded">
-          <div class="px-3 py-1 border-bottom">
-          <%= f.radio_button :leave_type, "sick", class: "form-check-input" %>
+        <div class="px-3 py-1 border-bottom">
+          <%= f.radio_button :leave_type, "sick", class: "form-check-input mx-1", required: true,
+            data: {
+              action: "input->leave-request#handleTypeSelect"
+            } %>
           <%= f.label :leave_type_sick, "Sick", class: "form-check-label" %>
-          </div>
-          <div class="px-3 py-1">
-          <%= f.radio_button :leave_type, "vacation", class: "form-check-input" %>
+          (<span data-leave-request-target="remainingSL"><%= @remaining_sl %></span> left)
+        </div>
+        <div class="px-3 py-1">
+          <%= f.radio_button :leave_type, "vacation", class: "form-check-input mx-1",
+            data: {
+              action: "input->leave-request#handleTypeSelect"
+            } %>
           <%= f.label :leave_type_vacation, "Vacation", class: "form-check-label" %>
-          </div>
+          (<span data-leave-request-target="remainingVL"><%= @remaining_vl %></span> left)
+        </div>
       </div>
-      </div>
-      <div class="col-7">
+    </div>
+    <div class="col-7">
       <%= f.label :reason, class: "form-label" %>
       <%= f.text_area :reason, class: "form-control" %>
-      </div>
+    </div>
   </div>
 
   <div class="d-flex my-3">
-      <%= f.submit 'File Leave', class: "btn btn-success col-12" %>
+    <%= f.submit 'File Leave', class: "btn btn-success col-12" %>
   </div>
 <% end %>

--- a/app/views/leaves/edit.html.erb
+++ b/app/views/leaves/edit.html.erb
@@ -1,13 +1,4 @@
-
 <div class="container col-12 col-md-6 my-4">
-  <%= render 'shared/flashes' %>
-  <%= render 'shared/toast' %>
-  <% if @leave.errors.any? %>
-    <% @leave.errors.full_messages.each do |message| %>
-      <div><%= message %></div>
-    <% end %>
-  <% end %>
-
   <h2>Edit Leave Request</h2>
   <%= render "form", leave: @leave %>
 </div>

--- a/app/views/leaves/index.html.erb
+++ b/app/views/leaves/index.html.erb
@@ -5,11 +5,55 @@
 
   <h2><%= current_employee.nickname %>'s Leaves</h2>
 
+  <div class="my-4">
+    <%= form_with(url: leaves_path, method: :get) do |f| %>
+      <div class="card">
+        <div class="card-body d-flex flex-row align-items-center h-100">
+          <div class="mx-2">
+            <%= f.label :leave_type, "Leave type", class: "form-label" %>
+            <%= f.select :leave_type, options_for_select(["Sick", "Vacation"], selected: params[:leave_type]), { prompt: "Select type" }, class: "form-select" %>
+          </div>
+          <div class="mx-2">
+            <%= f.label :status, "Status", class: "form-label" %>
+            <%= f.select :status, options_for_select(["Pending", "Approved", "Rejected", "Cancelled"], selected: params[:status]), { prompt: "Select status" }, class: "form-select" %>
+          </div>
+          <div class="mx-2">
+            <%= f.label :month, "Month", class: "form-label" %>
+            <%= f.select :month, options_for_select(@months, selected: params[:month]), { prompt: "Select month" }, class: "form-select" %>
+          </div>
+          <div class="mx-2">
+            <%= f.label :year, "Year", class: "form-label" %>
+            <%= f.select :year, options_for_select(@years, selected: params[:year]), { prompt: "Select year" }, class: "form-select" %>
+          </div>
+          <div class="mx-2 w-25">
+            <%= f.submit "Filter", class: "btn btn-primary w-100" %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
 
+  <div class="my-2 d-flex flex-row">
+    <div class="card w-50 me-2 alert alert-warning">
+      <h4>SL: <span class="fw-bold"><%= @remaining_sl %>/15</span> remaining</h4>
+      <div>
+        <span class="fw-bold"><%= @approved_sl %></span> approved,
+        <span class="fw-bold"><%= @pending_sl %></span> pending
+      </div>
+    </div>
+    <div class="w-50 ms-2 alert alert-info">
+      <h4>VL: <span class="fw-bold"><%= @remaining_vl %>/15</span> remaining</h4>
+      <div>
+        <span class="fw-bold"><%= @approved_vl %></span> approved,
+        <span class="fw-bold"><%= @pending_vl %></span> pending
+      </div>
+    </div>
+  </div>
+  
 
   <% @leaves.each do |leave| %>
     <div class="my-1 card">
-      <div class="card-body">
+      <div class="card-body border-start rounded border-4 <%= get_type_border(leave.leave_type) %>">
         <div class="card-title row align-items-center">
           <div class="col-9">
             <h4><%= leave.day_count %>-day <%= leave.leave_type.capitalize %> Leave</h4>

--- a/app/views/leaves/new.html.erb
+++ b/app/views/leaves/new.html.erb
@@ -1,12 +1,4 @@
 <div class="container col-12 col-md-6 my-4">
-  <%= render 'shared/flashes' %>
-  <%= render 'shared/toast' %>
-  <% if @leave.errors.any? %>
-    <% @leave.errors.full_messages.each do |message| %>
-      <div><%= message %></div>
-    <% end %>
-  <% end %>
-
   <h2>New Leave Request</h2>
   <%= render "form", leave: @leave %>
 </div>


### PR DESCRIPTION
## Changelog

### Features

#### Controller
- added instance variables for filters and leave count queries
    - for edit, add an extra condition such that self is not counted towards the total leaves
- active admin
    - enable my thing 

#### View
- index
    - added leave count display
    - added filters
    - added color indicators to leave type
- new/edit
    - added leave count display as well (on `leave_type` field) 
    - moved alerts to the form component for less redundancy
    - added validation with stimulus
        - prevent submission if day count exceeds remaining leaves

#### Model
- added scopes for common queries
- added validation
    - prevent overlapping leaves
 
## How to check
- log in to an employee account and file leaves if needed
    - verify that remaining leaves are displayed (only approved and pending should be counted)
    - verify that filters are working
- create a new leave or edit an existing leave
    - verify that it shows an error if you create a leave that overlaps with your existing leaves (approved and pending)
    - verify that it shows an error if you create a leave that goes beyond remaining leaves (which are displayed on `leave_type` field)
- log in as admin
    - verify that leaves can be created by an admin for a user that doesn't have login credentials 