### PR TITLE
fix: unpaid leaves and other improvements

### DIFF
--- a/app/controllers/leaves_controller.rb
+++ b/app/controllers/leaves_controller.rb
@@ -18,7 +18,7 @@ class LeavesController < ApplicationController
     @leaves = @leaves.where("extract(year from start_date) = ? or extract(year from end_date) = ?", params[:year], params[:year]) if params[:year].present?
 
     @past_leaves = @leaves.where(start_date: ..(Date.today-1.day)).order("start_date desc")
-    @upcoming_leaves = @leaves.where(start_date: (Date.today)..)
+    @upcoming_leaves = @leaves.where(start_date: (Date.today)..).order("start_date asc")
   end
 
   def new
@@ -76,7 +76,7 @@ class LeavesController < ApplicationController
   end
 
   def leave_counts
-    @all_leaves = current_employee.leaves.order("start_date asc")
+    @all_leaves = current_employee.leaves
 
     @pending_sl = @all_leaves.sick_leaves.pending_leaves.sum(:day_count)
     @pending_vl = @all_leaves.vacation_leaves.pending_leaves.sum(:day_count)

--- a/app/controllers/leaves_controller.rb
+++ b/app/controllers/leaves_controller.rb
@@ -42,7 +42,8 @@ class LeavesController < ApplicationController
 
   def update
     if @leave.update(leave_params)
-      redirect_to leaves_path, notice: "Leave request updated successfully!"
+      flash[:success] = @leave.leave_type.capitalize + " leave request updated successfully."
+      redirect_to leaves_path
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/leaves_controller.rb
+++ b/app/controllers/leaves_controller.rb
@@ -16,6 +16,9 @@ class LeavesController < ApplicationController
     @leaves = @leaves.where(status: params[:status].downcase) if params[:status].present?
     @leaves = @leaves.where("extract(month from start_date) = ? or extract(month from end_date) = ?", params[:month], params[:month]) if params[:month].present?
     @leaves = @leaves.where("extract(year from start_date) = ? or extract(year from end_date) = ?", params[:year], params[:year]) if params[:year].present?
+
+    @past_leaves = @leaves.where(start_date: ..(Date.today-1.day)).order("start_date desc")
+    @upcoming_leaves = @leaves.where(start_date: (Date.today)..)
   end
 
   def new

--- a/app/controllers/leaves_controller.rb
+++ b/app/controllers/leaves_controller.rb
@@ -25,7 +25,8 @@ class LeavesController < ApplicationController
   def create
     @leave = current_employee.leaves.build(leave_params)
     if @leave.save
-      redirect_to leaves_path, notice: "Leave request created successfully!"
+      flash[:success] = @leave.leave_type.capitalize + " leave request filed successfully."
+      redirect_to leaves_path
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/leaves_controller.rb
+++ b/app/controllers/leaves_controller.rb
@@ -51,7 +51,8 @@ class LeavesController < ApplicationController
 
   def cancel
     if @leave.update(status: "cancelled")
-      redirect_to leaves_path, notice: "Leave request cancelled!"
+      flash[:success] = "Leave request cancelled!"
+      redirect_to leaves_path
     else
       render :index, status: :unprocessable_entity
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,8 @@ module ApplicationHelper
   def alert_class(type)
     {
       success: "alert-success",
-      error: "alert-danger"
+      error: "alert-danger",
+      alert: "alert-secondary"
     }[type.to_sym]
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,7 @@ import PopoverController from "./popover_controller";
 import ImageValidationController from "./image_validation_controller";
 import FormValidationController from "./form_validation_controller";
 import LeaveRequestController from "./leave_request_controller";
+import TooltipController from "./tooltip_controller";
 
 application.register("select", SelectController);
 application.register("employee_select", EmployeeSelectController);
@@ -15,3 +16,4 @@ application.register("popover", PopoverController);
 application.register("image-validation", ImageValidationController);
 application.register("form-validation", FormValidationController);
 application.register("leave-request", LeaveRequestController);
+application.register("tooltip", TooltipController);

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -8,6 +8,7 @@ import ImageValidationController from "./image_validation_controller";
 import FormValidationController from "./form_validation_controller";
 import LeaveRequestController from "./leave_request_controller";
 import TooltipController from "./tooltip_controller";
+import ModalController from "./modal_controller";
 
 application.register("select", SelectController);
 application.register("employee_select", EmployeeSelectController);
@@ -17,3 +18,4 @@ application.register("image-validation", ImageValidationController);
 application.register("form-validation", FormValidationController);
 application.register("leave-request", LeaveRequestController);
 application.register("tooltip", TooltipController);
+application.register("modal", ModalController);

--- a/app/javascript/controllers/leave_request_controller.js
+++ b/app/javascript/controllers/leave_request_controller.js
@@ -14,7 +14,6 @@ export default class extends Controller {
     this.selectedType = document.querySelector(
       "input[type='radio']:checked",
     )?.value;
-    this.errors = [];
   }
 
   handleStartDateChange() {
@@ -55,7 +54,6 @@ export default class extends Controller {
     const startDate = this.startDateTarget.value;
     let dayCount = this.dayCountTarget.value;
 
-    if (dayCount > 15) this.dayCountTarget.value = 15;
     if (dayCount < 1) this.dayCountTarget.value = 1;
 
     dayCount = this.dayCountTarget.value;
@@ -84,21 +82,7 @@ export default class extends Controller {
     }
 
     if (dayCount > remainingLeaves) {
-      event.preventDefault();
-      this.errors.push(
-        "Day count cannot be greater than your remaining leaves.",
-      );
-    }
-
-    this.showErrors();
-  }
-
-  showErrors() {
-    if (this.errors.length > 0) {
-      let errorText = "";
-      this.errors.forEach((error) => (errorText += error + "<br />"));
-      document.getElementById("frontendErrors").innerHTML = errorText;
-      document.getElementById("frontendErrors").removeAttribute("hidden");
+      // TODO: modal
     }
   }
 

--- a/app/javascript/controllers/leave_request_controller.js
+++ b/app/javascript/controllers/leave_request_controller.js
@@ -81,8 +81,11 @@ export default class extends Controller {
       remainingLeaves = parseInt(this.remainingVLTarget.innerHTML);
     }
 
-    if (dayCount > remainingLeaves) {
-      // TODO: modal
+    if (dayCount > remainingLeaves && event.submitter.id != "modalConfirm") {
+      event.preventDefault();
+
+      const trigger = new CustomEvent("modal-open");
+      window.dispatchEvent(trigger);
     }
   }
 

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus";
+import * as bootstrap from "bootstrap";
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  static targets = ["modal"];
+
+  connect() {
+    this.modal = new bootstrap.Modal(this.modalTarget);
+  }
+
+  open() {
+    this.modal.show();
+  }
+
+  close() {
+    this.modal.hide();
+  }
+}

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus";
+import * as bootstrap from "bootstrap";
+
+// Connects to data-controller="tooltip"
+export default class extends Controller {
+  connect() {
+    this.initializeTooltips();
+  }
+
+  initializeTooltips() {
+    const tooltipTriggerList = document.querySelectorAll(
+      '[data-bs-toggle="tooltip"]',
+    );
+    const tooltipList = [...tooltipTriggerList].map(
+      (tooltipTriggerEl) => new bootstrap.Tooltip(tooltipTriggerEl),
+    );
+  }
+}

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -8,6 +8,7 @@ class Employee < ApplicationRecord
 
   validates :nickname, presence: true, uniqueness: true
   validates :email, uniqueness: true, allow_nil: true
+  validates_confirmation_of :password
 
   before_validation :convert_blank_to_nil
 

--- a/app/models/leave.rb
+++ b/app/models/leave.rb
@@ -10,7 +10,7 @@ class Leave < ApplicationRecord
   validates :day_count, presence: true
   validates :leave_type, presence: true
 
-  validate :end_date_must_be_after_start_date, :day_count_must_be_in_range, :no_overlapping_dates
+  validate :end_date_must_be_after_start_date, :day_count_must_be_countable, :no_overlapping_dates
 
   scope :sick_leaves, -> { where(leave_type: "sick") }
   scope :vacation_leaves, -> { where(leave_type: "vacation") }
@@ -27,9 +27,9 @@ class Leave < ApplicationRecord
     end
   end
 
-  def day_count_must_be_in_range
-    if day_count > 15 || day_count < 1
-      errors.add(:day_count, "must be between 1 to 15 days.")
+  def day_count_must_be_countable
+    if day_count < 1
+      errors.add(:day_count, "must be greater than 0.")
     end
   end
 

--- a/app/views/employees/registrations/edit.html.erb
+++ b/app/views/employees/registrations/edit.html.erb
@@ -7,7 +7,7 @@
     <% if current_employee.sign_in_count == 1 %>
       <div class="form-group my-3 px-3">
         <div class="alert alert-info" role="alert">
-          Please change your temporary password.
+          You may change your temporary password.
         </div>
       </div>
     <% end %>
@@ -46,7 +46,5 @@
         <%= f.submit "Update", class: "btn w-100 btn-primary" %>
       </div>
     <% end %>
-
-    <%= link_to "Back", :back, class: "px-3" %>
   </div>
 </div>

--- a/app/views/employees/registrations/edit.html.erb
+++ b/app/views/employees/registrations/edit.html.erb
@@ -4,6 +4,8 @@
       <h2 class="fw-semibold text-center">Update <%= resource_name.to_s.humanize %></h2>
     </div>
 
+    <%= render "employees/shared/error_messages", resource: resource %>
+
     <% if current_employee.sign_in_count == 1 %>
       <div class="form-group my-3 px-3">
         <div class="alert alert-info" role="alert">
@@ -13,8 +15,6 @@
     <% end %>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-      <%= render "employees/shared/error_messages", resource: resource %>
-
       <div class="form-group my-3 px-3 field">
         <%= f.label :email, class: "form-label" %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", disabled: true  %>

--- a/app/views/employees/sessions/new.html.erb
+++ b/app/views/employees/sessions/new.html.erb
@@ -4,6 +4,8 @@
       <h2 class="fw-semibold text-center">Employee Sign in</h2>
     </div>
 
+    <%= render 'shared/flashes' %>
+
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="form-group my-3 px-3 field">
         <%= f.label :email, class: "form-label" %>

--- a/app/views/employees/shared/_error_messages.html.erb
+++ b/app/views/employees/shared/_error_messages.html.erb
@@ -1,11 +1,9 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
+  <div id="error_explanation" class="alert alert-danger" data-turbo-cache="false">
+    <%= I18n.t("errors.messages.not_saved",
+                count: resource.errors.count,
+                resource: resource.class.model_name.human.downcase)
+     %>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg shadow-sm">
+<nav class="navbar navbar-expand-lg shadow-sm bg-light fixed-top z-3">
   <div class="container-fluid">
     <div>
       <a class="navbar-brand" href="/">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,8 @@
 
   <body>
     <%= render 'layouts/navbar' %>
-    <%= yield %>
+    <div style="margin-top: 56px;">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/leaves/_form.html.erb
+++ b/app/views/leaves/_form.html.erb
@@ -1,5 +1,4 @@
 <%= render 'shared/flashes' %>
-<%= render 'shared/toast' %>
 <% if @leave.errors.any? %>
   <% @leave.errors.full_messages.each do |message| %>
     <div class="alert alert-danger"><%= message %></div>

--- a/app/views/leaves/_form.html.erb
+++ b/app/views/leaves/_form.html.erb
@@ -66,6 +66,14 @@
     </div>
   </div>
 
+  <div data-controller="modal">
+    <%= render "modal",
+          title: "File leave",
+          content: "Your leave's day count is greater than your remaining leaves. Are you sure you want to file it anyway?",
+          form: f
+    %>
+  </div>
+
   <div class="d-flex my-3">
     <%= f.submit 'File Leave', class: "btn btn-success col-12" %>
   </div>

--- a/app/views/leaves/_form.html.erb
+++ b/app/views/leaves/_form.html.erb
@@ -5,7 +5,6 @@
     <div class="alert alert-danger"><%= message %></div>
   <% end %>
 <% end %>
-<div id="frontendErrors" class="alert alert-danger" hidden></div>
 
 <%= form_with(model: @leave, data: { controller: "leave-request", action: "submit->leave-request#validateForm" }) do |f| %>
   <div class="row my-2">
@@ -33,7 +32,7 @@
       </div>
       <div class="col-2">
       <%= f.label :day_count, class: "form-label" %>
-      <%= f.number_field :day_count, class: "form-control", min: 1, max: 15, required: true, 
+      <%= f.number_field :day_count, class: "form-control", min: 1, required: true, 
         data: {
           "leave-request-target": "dayCount",
           action: "input->leave-request#handleDayCountChange"
@@ -50,7 +49,7 @@
               action: "input->leave-request#handleTypeSelect"
             } %>
           <%= f.label :leave_type_sick, "Sick", class: "form-check-label" %>
-          (<span data-leave-request-target="remainingSL"><%= @remaining_sl %></span> left)
+          (<span data-leave-request-target="remainingSL"><%= @remaining_sl < 0 ? 0 : @remaining_sl %></span> left)
         </div>
         <div class="px-3 py-1">
           <%= f.radio_button :leave_type, "vacation", class: "form-check-input mx-1",
@@ -58,7 +57,7 @@
               action: "input->leave-request#handleTypeSelect"
             } %>
           <%= f.label :leave_type_vacation, "Vacation", class: "form-check-label" %>
-          (<span data-leave-request-target="remainingVL"><%= @remaining_vl %></span> left)
+          (<span data-leave-request-target="remainingVL"><%= @remaining_vl < 0 ? 0 : @remaining_vl %></span> left)
         </div>
       </div>
     </div>

--- a/app/views/leaves/_header.html.erb
+++ b/app/views/leaves/_header.html.erb
@@ -1,0 +1,37 @@
+<div class="py-2 hero-section fixed-top z-2" style="margin-top: 56px;">
+  <div class="container col-12 col-lg-6 py-4">
+    <div class="row align-items-center me-2">
+      <h2 class="col-9 fw-bold"><%= current_employee.nickname %>'s time off</h2>
+      <a class="col-3 btn btn-success" href="<%= new_leave_path() %>">
+        File Leave
+      </a>
+    </div>
+
+    <div class="mt-4">
+      <%= form_with(url: leaves_path, method: :get) do |f| %>
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title mx-2">Filters</h5>
+            <div class="d-flex flex-row align-items-center">
+              <div class="mx-2">
+                <%= f.select :leave_type, options_for_select(["Sick", "Vacation"], selected: params[:leave_type]), { prompt: "Select type" }, class: "form-select" %>
+              </div>
+              <div class="mx-2">
+                <%= f.select :status, options_for_select(["Pending", "Approved", "Rejected", "Cancelled"], selected: params[:status]), { prompt: "Select status" }, class: "form-select" %>
+              </div>
+              <div class="mx-2">
+                <%= f.select :month, options_for_select(@months, selected: params[:month]), { prompt: "Select month" }, class: "form-select" %>
+              </div>
+              <div class="mx-2">
+                <%= f.select :year, options_for_select(@years, selected: params[:year]), { prompt: "Select year" }, class: "form-select" %>
+              </div>
+              <div class="mx-2 w-25">
+                <%= f.submit "Filter", class: "btn btn-primary w-100" %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/leaves/_modal.html.erb
+++ b/app/views/leaves/_modal.html.erb
@@ -1,0 +1,30 @@
+<div
+  class="modal fade"
+  tabindex="-1"
+  role="dialog"
+  aria-hidden="false"
+  data-modal-target="modal"
+  data-action="modal-open@window->modal#open"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title fs-5" id="exampleModalLabel">
+          <%= title %>
+        </h4>
+        <button type="button" class="btn-close" data-action="modal#close" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <%= content %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-action="modal#close">No</button>
+        <% if !form.nil? %>
+          <%= form.submit "Yes", class: "btn btn-primary", id: "modalConfirm" %>
+        <% else %>
+          <button type="button" class="btn btn-primary">Yes</button>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/leaves/edit.html.erb
+++ b/app/views/leaves/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="container col-12 col-md-6 my-4">
+<div class="container col-12 col-md-6 py-4">
   <h2>Edit Leave Request</h2>
   <%= render "form", leave: @leave %>
 </div>

--- a/app/views/leaves/index.html.erb
+++ b/app/views/leaves/index.html.erb
@@ -2,7 +2,12 @@
 <div class="container col-12 col-lg-6 my-4">
   <%= render 'shared/flashes' %>
 
-  <h2><%= current_employee.nickname %>'s Leaves</h2>
+  <div class="row align-items-center">
+    <h2 class="col-9"><%= current_employee.nickname %>'s Leaves</h2>
+    <a class="col-3 btn btn-primary" href="<%= new_leave_path() %>">
+      File Leave Request
+    </a>
+  </div>
 
   <div class="my-4">
     <%= form_with(url: leaves_path, method: :get) do |f| %>
@@ -58,54 +63,69 @@
       </div>
     </div>
   </div>
-  
 
-  <% @leaves.each do |leave| %>
-    <div class="my-1 card">
-      <div class="card-body border-start rounded border-4 <%= get_type_border(leave.leave_type) %>">
-        <div class="card-title row align-items-center">
-          <div class="col-9">
-            <h4><%= leave.day_count %>-day <%= leave.leave_type.capitalize %> Leave</h4>
-          </div>
-          <div class="col-3 d-flex justify-content-end">
-            <% if leave.status == "pending" %>
-              <a class="btn btn-secondary mx-1" href="<%= edit_leave_path(leave) %>">Edit</a>
-            <% end %>
-            <% if ["pending", "approved"].include? leave.status %>
-              <a class="btn btn-secondary mx-1" href="<%= cancel_leave_path(leave) %>" data-turbo-method="patch">Cancel</a>
-            <% end %>
-          </div>
-        </div>
-        <div class="card-text row">
-          <div class="col-6 row">
-            <div class="col-4">
-              <div>From:</div>
-              <div>To: </div>
-              <div>Reason: </div>
+  <div data-controller="modal">
+    <%= form_with(url: cancel_leaves_path, method: :post) do |f| %>
+      <%= f.hidden_field :id, class: "form-control" %>
+      <%= render "modal",
+            title: "Cancel",
+            content: "Are you sure you want to cancel this leave request?",
+            form: f
+      %>
+      <% @leaves.each do |leave| %>
+        <div class="my-1 card">
+          <div class="card-body border-start rounded border-4 <%= get_type_border(leave.leave_type) %>">
+            <div class="card-title row align-items-center">
+              <div class="col-9">
+                <%= leave.id %>
+                <h4><%= leave.day_count %>-day <%= leave.leave_type.capitalize %> Leave</h4>
+              </div>
+              <div class="col-3 d-flex justify-content-end">
+                <% if leave.status == "pending" %>
+                  <a class="btn btn-secondary mx-1" href="<%= edit_leave_path(leave) %>">Edit</a>
+                <% end %>
+                <% if ["pending", "approved"].include? leave.status %>
+                  <button class="btn btn-secondary mx-1"
+                          data-action="modal#open"
+                          onclick="event.preventDefault(); document.getElementById('id').value = <%= leave.id %>"
+                  >
+                    Cancel
+                  </button>
+                <% end %>
+              </div>
             </div>
-            <div class="col-8">
-              <div><%= leave.start_date.strftime("%Y %b %-d") %></div>
-              <div><%= leave.end_date.strftime("%Y %b %-d") %></div>
-              <div class="<%= "text-muted" if !leave.reason? %>"><%= leave.reason? ? leave.reason : "none" %></div>
-            </div>
-          </div>
-          <div class="col-6 row">
-            <div class="col-4">
-              <div>Updated: </div>
-              <div>Approver: </div>
-              <div>Status: </div>
-            </div>
-            <div class="col-8">
-              <div><%= leave.updated_at.strftime("%Y %b %-d, %I:%M%p") %></div>
-              <div><%= leave.approver.email %></div>
-              <div>
-                <span class="badge <%= get_status_badge(leave.status)%>"><%= leave.status.capitalize %></span>
+            <div class="card-text row">
+              <div class="col-6 row">
+                <div class="col-4">
+                  <div>From:</div>
+                  <div>To: </div>
+                  <div>Reason: </div>
+                </div>
+                <div class="col-8">
+                  <div><%= leave.start_date.strftime("%Y %b %-d") %></div>
+                  <div><%= leave.end_date.strftime("%Y %b %-d") %></div>
+                  <div class="<%= "text-muted" if !leave.reason? %>"><%= leave.reason? ? leave.reason : "none" %></div>
+                </div>
+              </div>
+              <div class="col-6 row">
+                <div class="col-4">
+                  <div>Updated: </div>
+                  <div>Approver: </div>
+                  <div>Status: </div>
+                </div>
+                <div class="col-8">
+                  <div><%= leave.updated_at.strftime("%Y %b %-d, %I:%M%p") %></div>
+                  <div><%= leave.approver.email %></div>
+                  <div>
+                    <span class="badge <%= get_status_badge(leave.status)%>"><%= leave.status.capitalize %></span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </div>
-  <% end %>
+      <% end %>
+    <% end %>
+  </div>
 </div>
 

--- a/app/views/leaves/index.html.erb
+++ b/app/views/leaves/index.html.erb
@@ -33,16 +33,26 @@
     <% end %>
   </div>
 
-  <div class="my-2 d-flex flex-row">
+  <div class="my-2 d-flex flex-row" data-controller="tooltip">
     <div class="card w-50 me-2 alert alert-warning">
-      <h4>SL: <span class="fw-bold"><%= @remaining_sl %>/15</span> remaining</h4>
+      <% if @remaining_sl < 0 %>
+        <span class="position-absolute end-0 me-3 mt-1" data-bs-toggle="tooltip" data-bs-title="You've filed more than 15 SLs (<%= -@remaining_sl %> above limit)">
+          <i style="width: 24px; height: 24px;" class="fa-solid fa-circle-exclamation"></i>
+        </span>
+      <% end %>
+      <h4>SL: <span class="fw-bold"><%= @remaining_sl < 0 ? 0 : @remaining_sl %>/15</span> remaining</h4>
       <div>
         <span class="fw-bold"><%= @approved_sl %></span> approved,
         <span class="fw-bold"><%= @pending_sl %></span> pending
       </div>
     </div>
     <div class="w-50 ms-2 alert alert-info">
-      <h4>VL: <span class="fw-bold"><%= @remaining_vl %>/15</span> remaining</h4>
+      <% if @remaining_vl < 0 %>
+        <span class="position-absolute end-0 me-3 mt-1" data-bs-toggle="tooltip" data-bs-title="You've filed more than 15 VLs (<%= -@remaining_vl %> above limit)">
+          <i style="width: 24px; height: 24px;" class="fa-solid fa-circle-exclamation"></i>
+        </span>
+      <% end %>
+      <h4>VL: <span class="fw-bold"><%= @remaining_vl < 0 ? 0 : @remaining_vl %>/15</span> remaining</h4>
       <div>
         <span class="fw-bold"><%= @approved_vl %></span> approved,
         <span class="fw-bold"><%= @pending_vl %></span> pending

--- a/app/views/leaves/index.html.erb
+++ b/app/views/leaves/index.html.erb
@@ -1,7 +1,6 @@
 
 <div class="container col-12 col-lg-6 my-4">
   <%= render 'shared/flashes' %>
-  <%= render 'shared/toast' %>
 
   <h2><%= current_employee.nickname %>'s Leaves</h2>
 

--- a/app/views/leaves/index.html.erb
+++ b/app/views/leaves/index.html.erb
@@ -1,50 +1,16 @@
+<%= render "header" %>
 
-<div class="container col-12 col-lg-6 my-4">
-  <%= render 'shared/flashes' %>
+<div class="container col-lg-6 py-2 z-1" style="margin-top: 300px;" data-controller="tooltip">
+  <%= render "shared/flashes" %>
 
-  <div class="row align-items-center">
-    <h2 class="col-9"><%= current_employee.nickname %>'s Leaves</h2>
-    <a class="col-3 btn btn-primary" href="<%= new_leave_path() %>">
-      File Leave Request
-    </a>
-  </div>
-
-  <div class="my-4">
-    <%= form_with(url: leaves_path, method: :get) do |f| %>
-      <div class="card">
-        <div class="card-body d-flex flex-row align-items-center h-100">
-          <div class="mx-2">
-            <%= f.label :leave_type, "Leave type", class: "form-label" %>
-            <%= f.select :leave_type, options_for_select(["Sick", "Vacation"], selected: params[:leave_type]), { prompt: "Select type" }, class: "form-select" %>
-          </div>
-          <div class="mx-2">
-            <%= f.label :status, "Status", class: "form-label" %>
-            <%= f.select :status, options_for_select(["Pending", "Approved", "Rejected", "Cancelled"], selected: params[:status]), { prompt: "Select status" }, class: "form-select" %>
-          </div>
-          <div class="mx-2">
-            <%= f.label :month, "Month", class: "form-label" %>
-            <%= f.select :month, options_for_select(@months, selected: params[:month]), { prompt: "Select month" }, class: "form-select" %>
-          </div>
-          <div class="mx-2">
-            <%= f.label :year, "Year", class: "form-label" %>
-            <%= f.select :year, options_for_select(@years, selected: params[:year]), { prompt: "Select year" }, class: "form-select" %>
-          </div>
-          <div class="mx-2 w-25">
-            <%= f.submit "Filter", class: "btn btn-primary w-100" %>
-          </div>
-        </div>
-      </div>
-    <% end %>
-  </div>
-
-  <div class="my-2 d-flex flex-row" data-controller="tooltip">
+  <div class="my-2 d-flex flex-row">
     <div class="card w-50 me-2 alert alert-warning">
       <% if @remaining_sl < 0 %>
         <span class="position-absolute end-0 me-3 mt-1" data-bs-toggle="tooltip" data-bs-title="You've filed more than 15 SLs (<%= -@remaining_sl %> above limit)">
           <i style="width: 24px; height: 24px;" class="fa-solid fa-circle-exclamation"></i>
         </span>
       <% end %>
-      <h4>SL: <span class="fw-bold"><%= @remaining_sl < 0 ? 0 : @remaining_sl %>/15</span> remaining</h4>
+      <h3>SL: <span class="fw-bold"><%= @remaining_sl < 0 ? 0 : @remaining_sl %>/15</span> remaining</h3>
       <div>
         <span class="fw-bold"><%= @approved_sl %></span> approved,
         <span class="fw-bold"><%= @pending_sl %></span> pending
@@ -56,76 +22,158 @@
           <i style="width: 24px; height: 24px;" class="fa-solid fa-circle-exclamation"></i>
         </span>
       <% end %>
-      <h4>VL: <span class="fw-bold"><%= @remaining_vl < 0 ? 0 : @remaining_vl %>/15</span> remaining</h4>
+      <h3>VL: <span class="fw-bold"><%= @remaining_vl < 0 ? 0 : @remaining_vl %>/15</span> remaining</h3>
       <div>
         <span class="fw-bold"><%= @approved_vl %></span> approved,
         <span class="fw-bold"><%= @pending_vl %></span> pending
       </div>
     </div>
   </div>
+</div>
 
-  <div data-controller="modal">
-    <%= form_with(url: cancel_leaves_path, method: :post) do |f| %>
-      <%= f.hidden_field :id, class: "form-control" %>
-      <%= render "modal",
-            title: "Cancel",
-            content: "Are you sure you want to cancel this leave request?",
-            form: f
-      %>
-      <% @leaves.each do |leave| %>
-        <div class="my-1 card">
-          <div class="card-body border-start rounded border-4 <%= get_type_border(leave.leave_type) %>">
-            <div class="card-title row align-items-center">
-              <div class="col-9">
-                <%= leave.id %>
-                <h4><%= leave.day_count %>-day <%= leave.leave_type.capitalize %> Leave</h4>
-              </div>
-              <div class="col-3 d-flex justify-content-end">
-                <% if leave.status == "pending" %>
-                  <a class="btn btn-secondary mx-1" href="<%= edit_leave_path(leave) %>">Edit</a>
-                <% end %>
-                <% if ["pending", "approved"].include? leave.status %>
-                  <button class="btn btn-secondary mx-1"
-                          data-action="modal#open"
-                          onclick="event.preventDefault(); document.getElementById('id').value = <%= leave.id %>"
-                  >
-                    Cancel
-                  </button>
-                <% end %>
-              </div>
-            </div>
-            <div class="card-text row">
-              <div class="col-6 row">
-                <div class="col-4">
-                  <div>From:</div>
-                  <div>To: </div>
-                  <div>Reason: </div>
+<div class="container col-lg-6 py-2 z-1">
+  <div class="row">
+    <div class="col-6" data-controller="modal">
+      <%= form_with(url: cancel_leaves_path, method: :post) do |f| %>
+        <%= f.hidden_field :id, class: "form-control" %>
+        <%= render "modal",
+              title: "Cancel",
+              content: "Are you sure you want to cancel this leave request?",
+              form: f
+        %>
+        
+        <h4 class="fw-bold pb-2">Upcoming Leaves</h4>
+        <% if @upcoming_leaves.size == 0 %>
+          None
+        <% else %>
+          <% @upcoming_leaves.each do |leave| %>
+            <div class="my-1 card">
+              <div class="card-body border-start rounded border-4 <%= get_type_border(leave.leave_type) %>">
+                <div class="card-title row">
+                  <div class="col-9 d-flex flex-column justify-content-center">
+                    <h5><span class="fw-bold"><%= leave.leave_type.capitalize %></span> (<%= leave.day_count %> day<%= "s" if leave.day_count > 1 %>)</h5>
+                    <h6>
+                      <%= leave.start_date.strftime("%b %-d") %><%= ", " + leave.start_date.year.to_s if leave.start_date.year != leave.end_date.year %>
+                      - <%= leave.end_date.strftime("%b %-d, %Y") %>
+                    </h6>
+                  </div>
+                  <div class="col-3 d-flex flex-column align-items-end justify-content-start">
+                    <div class="badge <%= get_status_badge(leave.status)%> me-1">
+                      <%= leave.status.upcase %>
+                    </div>
+                    <div class="d-flex align-items-center my-1">
+                      <% if leave.status == "pending" %>
+                        <div class="col-6">
+                          <a class="btn btn-secondary mx-1"
+                              href="<%= edit_leave_path(leave) %>"
+                              data-bs-toggle="tooltip"
+                              data-bs-title="Edit"
+                          >
+                            <i class="fa-solid fa-pen-to-square"></i>
+                          </a>
+                        </div>
+                      <% end %>
+                      <% if ((["pending", "approved"].include? leave.status) && (leave.start_date - Date.today >= 0)) %>
+                        <div class="col-6">
+                          <button class="btn btn-secondary mx-1"
+                                  data-action="modal#open"
+                                  onclick="event.preventDefault(); document.getElementById('id').value = <%= leave.id %>"
+                                  data-bs-toggle="tooltip"
+                                  data-bs-title="Cancel"
+                          >
+                            <i class="fa-solid fa-ban"></i>
+                          </button>
+                        </div>
+                      <% end %>
+                    </div>
+                  </div>
                 </div>
-                <div class="col-8">
-                  <div><%= leave.start_date.strftime("%Y %b %-d") %></div>
-                  <div><%= leave.end_date.strftime("%Y %b %-d") %></div>
-                  <div class="<%= "text-muted" if !leave.reason? %>"><%= leave.reason? ? leave.reason : "none" %></div>
-                </div>
-              </div>
-              <div class="col-6 row">
-                <div class="col-4">
-                  <div>Updated: </div>
-                  <div>Approver: </div>
-                  <div>Status: </div>
-                </div>
-                <div class="col-8">
-                  <div><%= leave.updated_at.strftime("%Y %b %-d, %I:%M%p") %></div>
-                  <div><%= leave.approver.email %></div>
-                  <div>
-                    <span class="badge <%= get_status_badge(leave.status)%>"><%= leave.status.capitalize %></span>
+                <div class="card-text row">
+                  <div class="col-9">
+                    <div class="row">
+                      <div class="col-4">
+                        <div>Approver: </div>
+                        <div>Reason: </div>
+                      </div>
+                      <div class="col-8">
+                        <div><%= leave.approver.email %></div>
+                        <div class="<%= "text-muted" if !leave.reason? %>"><%= leave.reason? ? leave.reason : "none" %></div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </div>
-      <% end %>
+          <% end %>
+        <% end %>
+      </div>
     <% end %>
+
+    <div class="col-6">    
+      <h4 class="fw-bold pb-2">Past leaves</h4>
+      <% if @past_leaves.size == 0 %>
+        None
+      <% else %>
+          <% @past_leaves.each do |leave| %>
+            <div class="my-1 card">
+              <div class="card-body border-start rounded border-4 bg-body-secondary <%= get_type_border(leave.leave_type) %>">
+                <div class="card-title row">
+                  <div class="col-9 d-flex flex-column justify-content-center">
+                    <h5><span class="fw-bold"><%= leave.leave_type.capitalize %></span> (<%= leave.day_count %> day<%= "s" if leave.day_count > 1 %>)</h5>
+                    <h6>
+                      <%= leave.start_date.strftime("%b %-d") %><%= ", " + leave.start_date.year.to_s if leave.start_date.year != leave.end_date.year %>
+                      - <%= leave.end_date.strftime("%b %-d, %Y") %>
+                    </h6>
+                  </div>
+                  <div class="col-3 d-flex flex-column align-items-end justify-content-start">
+                    <div class="badge <%= get_status_badge(leave.status)%> me-1">
+                      <%= leave.status.upcase %>
+                    </div>
+                    <div class="d-flex align-items-center my-1">
+                      <% if leave.status == "pending" %>
+                        <div class="col-6">
+                          <a class="btn btn-secondary mx-1"
+                              href="<%= edit_leave_path(leave) %>"
+                              data-bs-toggle="tooltip"
+                              data-bs-title="Edit"
+                          >
+                            <i class="fa-solid fa-pen-to-square"></i>
+                          </a>
+                        </div>
+                      <% end %>
+                      <% if ((["pending", "approved"].include? leave.status) && (leave.start_date - Date.today >= 0)) %>
+                        <div class="col-6">
+                          <button class="btn btn-secondary mx-1"
+                                  data-action="modal#open"
+                                  onclick="event.preventDefault(); document.getElementById('id').value = <%= leave.id %>"
+                                  data-bs-toggle="tooltip"
+                                  data-bs-title="Cancel"
+                          >
+                            <i class="fa-solid fa-ban"></i>
+                          </button>
+                        </div>
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+                <div class="card-text row">
+                  <div class="col-9">
+                    <div class="row">
+                      <div class="col-4">
+                        <div>Approver: </div>
+                        <div>Reason: </div>
+                      </div>
+                      <div class="col-8">
+                        <div><%= leave.approver.email %></div>
+                        <div class="<%= "text-muted" if !leave.reason? %>"><%= leave.reason? ? leave.reason : "none" %></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+    </div>
   </div>
 </div>
-

--- a/app/views/leaves/new.html.erb
+++ b/app/views/leaves/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container col-12 col-md-6 my-4">
+<div class="container col-12 col-md-6 py-4">
   <h2>New Leave Request</h2>
   <%= render "form", leave: @leave %>
 </div>

--- a/app/views/reimbursements/_form.html.erb
+++ b/app/views/reimbursements/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: reimbursement, data: { controller: "form-validation", action: "submit->form-validation#validateForm" }) do |form| %>
-  <div class="container col-12 col-md-6 my-2">
+  <div class="container col-12 col-md-6 py-2">
     <%= render 'shared/flashes' %>
     <%= render 'shared/toast' %>
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -28,7 +28,7 @@ en:
       password_change:
         subject: "Password Changed"
     omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      failure: 'Could not authenticate you from %{kind} because "%{reason}".'
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
@@ -43,12 +43,12 @@ en:
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
-      updated: "Your account has been updated successfully."
+      updated: ""
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
     sessions:
-      signed_in: "Signed in successfully."
-      signed_out: "Signed out successfully."
-      already_signed_out: "Signed out successfully."
+      signed_in: ""
+      signed_out: ""
+      already_signed_out: ""
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,9 @@ Rails.application.routes.draw do
     member do
       put :approve
       put :reject
-      patch :cancel
+    end
+    collection do
+      post :cancel
     end
   end
 


### PR DESCRIPTION
## Changelog

### Leaves
- account for submitted leaves with day count greater than remaining leaves
    - instead of throwing an error, show confirmation modal as a warning instead, and user can still choose to submit
    - on the My Leaves page, added an indicator with a tooltip on leave count display, if user's leaves are already above 15
        - bootstrap tooltips enabled in a stimulus controller

### Other improvements
- streamlined flash messages everywhere
    - made use of `alert_class` helper for leave notices
    - added styling to devise error messages
    - removed some devise flash success alerts as a compromise because they persist in unrelated pages and it'd be too much effort to work around
- show confirmation modal when cancelling leaves as well
    - changed `cancel` method to `post` such that it can be submitted as a form
- updated My Leaves page layout
    - filters now fixed on top of page, and added `hero-section` background
        - also made navbar fixed to top
    - separated upcoming leaves from past leaves
    - made leave cards more compact

## How to check
- devise
    - when logging in, verify that it shows proper flash messages when inputting wrong credentials
    - when updating your password, verify that it shows proper error messages when inputting invalid passwords
- creating or editing leaves
    - verify that when submitting the form, it will show a confirmation modal if day count > remaining leaves
    - verify that it shows a proper success flash message on submit
- cancelling leaves
    - verify that it also shows a confirmation modal when trying to cancel
    - verify that it shows a proper success flash message on submit